### PR TITLE
#161641279 Rename css modals and add img styling

### DIFF
--- a/UI/css/style.css
+++ b/UI/css/style.css
@@ -93,6 +93,7 @@ header a:hover{
 }
 #squares .box img{
     width: 90px;
+    border-radius: 50%;
 }
 
 /* Main pillar styling */

--- a/UI/css/style.css
+++ b/UI/css/style.css
@@ -63,35 +63,35 @@ header a:hover{
     font-weight: bold;
 }
 
-/* showcase */
+/* display */
 
-#showcase{
+#display{
     min-height: 400px;
     background: url('../img/showcase.jpg') no-repeat 0 -400px;
     text-align: center;
   
 }
-#showcase h1{
+#display h1{
     margin-top: 130px;
     font-size: 55px;
     margin-bottom: 10px;
 
 }
-#showcase p{
+#display p{
     font-size: 20px;
 }
-/* boxes */
-#boxes{
+/* squares */
+#squares{
     margin-top: 20px;
 }
 
-#boxes .box{
+#squares .box{
     float: left;
     text-align: center;
     width: 30%;
     padding: 10px;
 }
-#boxes .box img{
+#squares .box img{
     width: 90px;
 }
 

--- a/UI/index.html
+++ b/UI/index.html
@@ -24,14 +24,14 @@
         </div>
     </header>
 
-    <section id="showcase">
+    <section id="display">
         <div class="container">
             <h1>Welcome to Send-IT</h1>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae aliquet orci. Donec non magna vel purus commodo dictum vitae accumsan ipsum. Mauris eu tellus efficitur, ullamcorper arcu sed, feugiat justo. Suspendisse egestas laoreet purus, nec rhoncus leo auctor at.</p>
         </div>
     </section>
 
-    <section id="boxes">
+    <section id="squares">
         <div class="container">
             <div class="box">
                 <img src="./img/box1.jpg">


### PR DESCRIPTION
#### What does this PR do?
make the about-page feature branch more in sync with contents of the gh-pages branch
#### Description of Task to be completed?
delete redundant files, rename global css modals and section ids, and add styling for images on landing page 
#### How should this be manually tested?
click the link to the home page and one should see restructured images 
#### Any background context you want to provide?
this is a chore I am doing for a number of branches sprouting from gh-pages in the sendIT project directory
#### What are the relevant pivotal tracker stories?
#161641279
#### screenshot
About page
![about_page](https://user-images.githubusercontent.com/16785630/47834384-5e3f7600-ddb0-11e8-9204-3bf18b2dcda9.jpg)
landing_page
![landing_page](https://user-images.githubusercontent.com/16785630/47834413-744d3680-ddb0-11e8-92f4-7288c5f7a9e3.jpg)

