### PR TITLE
[#161709392] Restructure admin display and about page css

### DIFF
--- a/UI/about.html
+++ b/UI/about.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>About Send-IT</title>
+    <title>Send-IT</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="./css/about.css" />
     <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
@@ -18,15 +18,12 @@
             <nav>
                 <ul>
                     <li><a href="index.html">Home</a></li>
-                    <li><a href="registration.html">Register</a></li>
+                    <li><a href="register_page.html">Register</a></li>
                     <li><a href="login.html">Login</a></li>
                 </ul>
             </nav>
         </div>
     </header>
-
-    
-
     <section>
         <div class="container">
             <article id="about-col">
@@ -48,7 +45,7 @@
     </section>
     <section>
         <div class="container">
-            <h4>connect with us</h4>
+            <h4>Behold our presence on social platforms</h4>
             <a href="#"><i class="fab fa-facebook"></i></a>
             <a href="#"><i class="fab fa-twitter-square"></i></a>
             <a href="#"><i class="fab fa-google-plus-square"></i></a>

--- a/UI/css/about.css
+++ b/UI/css/about.css
@@ -70,41 +70,6 @@ header a:hover{
     font-weight: bold;
 }
 
-/* display */
-
-#display{
-    min-height: 400px;
-    background: url('../img/showcase.jpg') no-repeat 0 -400px;
-    text-align: center;
-  
-}
-#display h1{
-    margin-top: 130px;
-    font-size: 55px;
-    margin-bottom: 10px;
-
-}
-#display p{
-    font-size: 20px;
-}
-
-/* squares */
-
-#squares{
-    margin-top: 20px;
-}
-
-#squares .box{
-    float: left;
-    text-align: center;
-    width: 30%;
-    padding: 10px;
-}
-#squares .box img{
-    width: 90px;
-    border-radius: 50%;
-}
-
 /* Main pillar styling */
 #about{
     margin-top: 300px;
@@ -166,7 +131,6 @@ footer{
     header #brand,
     header nav,
     header nav li,
-    #squares .box
     article#about-col,
     aside#leftbar{
         float: none;
@@ -175,9 +139,6 @@ footer{
     }
     header{
         padding-bottom: 20px; 
-    }
-    #display h1{
-        margin-top: 40px;
     }
     .order button{
         display: block;

--- a/UI/css/admin_style.css
+++ b/UI/css/admin_style.css
@@ -16,19 +16,11 @@ article#about-col{
     float: right;
     width: 65%;
 }
-aside#leftbar .create input{
+aside#leftbar{
     float: left;
     width: 30%;
     margin-top: 10px;
 }
-.navy{
-    padding: 15px;
-    background: #0B5068;
-    color: #cccccc;
-    margin-top: 10px;
-    margin-bottom: 10px;
-}
-
 ul{
     margin: 0;
     padding: 0;
@@ -52,6 +44,16 @@ ul#orders li{
 .label{
     margin-bottom: 40px;
 }
+input[type=text], input[type=password] {
+    width: 100%;
+    padding: 12px 20px;
+    margin: 8px 0 8px 0;
+    display: inline-block;
+    border: 1px solid #ccc;
+    box-sizing: border-box;
+}
+
+
 
 /* header */
 header{
@@ -91,38 +93,6 @@ header a:hover{
     font-weight: bold;
 }
 
-/* display */
-
-#display{
-    min-height: 400px;
-    background: url('../img/showcase.jpg') no-repeat 0 -400px;
-    text-align: center;
-  
-}
-#display h1{
-    margin-top: 130px;
-    font-size: 55px;
-    margin-bottom: 10px;
-
-}
-#display p{
-    font-size: 20px;
-}
-/* square */
-#squares{
-    margin-top: 20px;
-}
-
-#squares .box{
-    float: left;
-    text-align: center;
-    width: 30%;
-    padding: 10px;
-}
-#squares .box img{
-    width: 90px;
-    border-radius: 50%;
-}
 
 /* footer */
 footer{
@@ -147,9 +117,6 @@ footer{
     }
     header{
         padding-bottom: 20px; 
-    }
-    #display h1{
-        margin-top: 40px;
     }
     .order button{
         display: block;

--- a/UI/orders_display_admin.html
+++ b/UI/orders_display_admin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Admin - Delivery Orders List</title>
+    <title>Send-IT</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="./css/admin_style.css" />
     <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
@@ -16,15 +16,12 @@
             </div>
             <nav>
                 <ul>
-                    <li><a href="home.html">Home</a></li>
+                    <li><a href="about.html">About</a></li>
                     <li><a href="index.html">Logout</a></li>
                 </ul>
             </nav>
         </div>
     </header>
-
-   
-
     <section>
         <div class="container">
             <article id="about-col">
@@ -35,9 +32,8 @@
                         <p>User: Hannibal Scorpio</p>
                         <p>Sent from: Muthunguri</p>
                         <p>Destination: Machakos</p>
-                        <p>status: Transit</p>
+                        <p>status: Transist</p>
                         <button class="button_1" type="submit">Toggle Status</button>
-                        <button class="button_1" type="submit">Order info</button>
                     </li>
                     <li>
                         <h3>'Autumn is here' monthly periodical</h3>
@@ -46,16 +42,14 @@
                         <p>Destination: Muranga</p>
                         <p>status: Arrived</p>
                         <button class="button_1" type="submit">Toggle Status</button>
-                        <button class="button_1" type="submit">Order info</button>
                     </li>
                     <li>
                         <h3>Two goats</h3>
                         <p>User: Homer Socrates</p>
                         <p>Sent from: Isiolo</p>
                         <p>Destination: Sagana</p>
-                        <p>status: Delayed</p>
+                        <p>status: Transist</p>
                         <button class="button_1" type="submit">Toggle Status</button>
-                        <button class="button_1" type="submit">Order info</button>
                     </li>
                 </ul>
             </article>
@@ -68,7 +62,7 @@
                         <input type="text" placeholder="item">
                     </div>
                     <div class="label">
-                        <label>Enter new Location:</label><br>
+                        <label>Present Location:</label><br>
                         <input type="text" placeholder="current location">
                     </div>
                     <button class="button_1" type="submit">Update</button>


### PR DESCRIPTION
#### What does this PR do?
removes redundant css on admin and about page css files
#### Description of Task to be completed?
making each stylesheet for the admin and about page more specific and polishing up the displays
#### How should this be manually tested?
clone repo into a local directory
`git clone --single-branch -b ch-admin-page-css-161709392 git@github.com:ipaullly/sendIT.git`
cd into the UI directory of the sendIT directory:
`cd sendIT/UI`
open `orders_display_admin.html` in your favorite browser
#### What are the relevant pivotal tracker stories?
#11 