### PR TITLE
[#162113691] Configure PUT cancel order to database

### DIFF
--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 from flask_restful import Api
-from .views import ParcelList, SingleParcel, ParcelStatus #, IndividualParcel, CancelParcel, UserOrders
+from .views import ParcelList, SingleParcel, ParcelStatus, ParcelLocation #, IndividualParcel, CancelParcel, UserOrders
 
 version2 = Blueprint('v2', __name__, url_prefix="/api/v2")
 
@@ -9,4 +9,4 @@ api = Api(version2)
 api.add_resource(ParcelList, '/parcels')
 api.add_resource(SingleParcel, '/parcels/<int:id>/destination')
 api.add_resource(ParcelStatus, '/parcels/<int:id>/status')
-#api.add_resource(CancelParcel, '/parcels/<int:id>/cancel')
+api.add_resource(ParcelLocation, '/parcels/<int:id>/presentLocation')

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 from flask_restful import Api
-from .views import ParcelList, SingleParcel, ParcelStatus, ParcelLocation #, IndividualParcel, CancelParcel, UserOrders
+from .views import ParcelList, SingleParcel, ParcelStatus, ParcelLocation, CancelParcel
 
 version2 = Blueprint('v2', __name__, url_prefix="/api/v2")
 
@@ -10,3 +10,4 @@ api.add_resource(ParcelList, '/parcels')
 api.add_resource(SingleParcel, '/parcels/<int:id>/destination')
 api.add_resource(ParcelStatus, '/parcels/<int:id>/status')
 api.add_resource(ParcelLocation, '/parcels/<int:id>/presentLocation')
+api.add_resource(CancelParcel, '/parcels/<int:id>/cancel')

--- a/app/api/v2/dbmodel.py
+++ b/app/api/v2/dbmodel.py
@@ -69,8 +69,9 @@ class SenditDb:
         """
         method that sends an update query to the database
         """
-        cls.cur.execute(query_string)
+        resp = cls.cur.execute(query_string)
         cls.conn.commit()
+        return resp
 
     @classmethod
     def drop_all(cls):

--- a/app/api/v2/dbmodel.py
+++ b/app/api/v2/dbmodel.py
@@ -26,8 +26,8 @@ class SenditDb:
         pickup_location character varying(50) NOT NULL,
         destination character varying(50) NOT NULL,
         pricing numeric NOT NULL,
-        current_location character varying(50),
         status character varying(10),
+        current_location character varying(50),
         timestamp timestamp default current_timestamp
         );
         CREATE TABLE IF NOT EXISTS users (
@@ -44,8 +44,9 @@ class SenditDb:
         """
         method that saves queries into the database
         """
-        cls.cur.execute(query_string, tuple_data)
+        response = cls.cur.execute(query_string, tuple_data)
         cls.conn.commit()
+        return response
     
     @classmethod
     def retrieve_one(cls, query_string):
@@ -79,4 +80,4 @@ class SenditDb:
         cls.cur.execute("""DROP TABLE IF EXISTS users CASCADE;\
         DROP TABLE IF EXISTS orders CASCADE;""")
         cls.conn.commit()
-    
+  

--- a/app/api/v2/models.py
+++ b/app/api/v2/models.py
@@ -18,11 +18,6 @@ class OrderParcel:
 
         input_query = """INSERT INTO orders (item_name, pickup_location, destination \
         , pricing, user_id) VALUES (%s, %s, %s, %s, %s);"""
-        user_query = """SELECT * FROM orders WHERE user_id={};""".format(user_id)
-        response = SenditDb.retrieve_one(user_query)
-        if response['item_name'] == item:
-            message = "User already ordered this item"
-            return message
         tup = (item, pickup, dest, pricing, user_id)
         SenditDb.add_to_db(input_query, tup)
         
@@ -62,8 +57,21 @@ class OrderParcel:
         response = SenditDb.retrieve_one(input_query)
         if not response:
             return False
-        status_query = """UPDATE orders SET status = 'status' WHERE order_id={}""".format(parcel_id)
+        status_query = """UPDATE orders SET status = '{}' WHERE order_id={}""".format(status, parcel_id)
         SenditDb.update_row(status_query)
         return payload
 
-    
+    def update_current_location(self, new_location, parcel_id):
+        """
+        updates the current location of the parcel delivery order
+        """
+        payload = {
+            "Updated location" : new_location
+        }
+        input_query = """SELECT * FROM orders WHERE order_id={}""".format(parcel_id)
+        response = SenditDb.retrieve_one(input_query)
+        if not response:
+            return False
+        status_query = """UPDATE orders SET current_location = '{}' WHERE order_id={}""".format(new_location, parcel_id)
+        SenditDb.update_row(status_query)
+        return payload

--- a/app/api/v2/models.py
+++ b/app/api/v2/models.py
@@ -42,7 +42,7 @@ class OrderParcel:
         response = SenditDb.retrieve_one(input_query)
         if not response:
             return False
-        update_query = """UPDATE orders SET destination = 'new_dest' WHERE order_id={}""".format(parcel_id)
+        update_query = """UPDATE orders SET destination = '{}' WHERE order_id={}""".format(new_dest, parcel_id)
         SenditDb.update_row(update_query)
         return payload
 
@@ -75,3 +75,17 @@ class OrderParcel:
         status_query = """UPDATE orders SET current_location = '{}' WHERE order_id={}""".format(new_location, parcel_id)
         SenditDb.update_row(status_query)
         return payload
+
+    def cancel_order(self, parcel_id):
+        """
+        cancels a parcel delivery order by id
+        """
+        input_query = """SELECT * FROM orders WHERE order_id={}""".format(parcel_id)
+        response = SenditDb.retrieve_one(input_query)
+        if not response:
+            return False
+        status_query = """UPDATE orders SET status = 'cancelled' WHERE order_id={}""".format(parcel_id)
+        SenditDb.update_row(status_query)
+        return True
+
+        

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -64,8 +64,13 @@ class ParcelList(Resource):
         """
         resp = order.order_list()
         if resp:
-            return jsonify(resp)
-        return jsonify({"message" : "No orders in the database"})
+            return make_response(jsonify({
+                "message" : "ok",
+                "data" : resp
+            }), 200)
+        return make_response(jsonify({
+                "message" : "No orders in the database"
+            }), 400) 
 
 
 class SingleParcel(Resource):
@@ -99,11 +104,10 @@ class ParcelStatus(Resource):
         PUT request to update parcel status to
         """ 
         order_status = request.get_json()['status']
-        item_id = request.get_json()['item_id']
         
         if order_status == 'In transit' or order_status == 'Arrived':
             
-            order_status = order.update_order_status(order_status, item_id)
+            order_status = order.update_order_status(order_status, id)
             if order_status:
                 return make_response(jsonify({
                     "message" : "Success",
@@ -118,4 +122,24 @@ class ParcelStatus(Resource):
                     "message" : "Status entered is invalid"
                 }), 400) 
     
+class ParcelLocation(Resource):
+    """
+    class for endpoint to cancel parcel order
+    """
+    def put(self, id):
+        """
+        PUT request to update parcel status to
+        """ 
+        order_location = request.get_json()['current_location']
+        
+        new_location = order.update_current_location(order_location, id)
+        if new_location:
+            return make_response(jsonify({
+                "message" : "Success",
+                "data" : new_location
+            }), 201)
+        else:
+            return make_response(jsonify({
+                "message" : "Update of current order failed. no order by that id"
+            }), 400)
     

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -142,4 +142,20 @@ class ParcelLocation(Resource):
             return make_response(jsonify({
                 "message" : "Update of current order failed. no order by that id"
             }), 400)
-    
+class CancelParcel(Resource):
+    """
+    class for endpoint to cancel parcel order
+    """
+    def put(self, id):
+        """
+        PUT request to update parcel status to 'cancelled'
+        """ 
+        cancel_parcel = order.cancel_order(id)
+        if cancel_parcel:
+            return make_response(jsonify({
+                "message" : "order is cancelled"
+            }), 201)
+        else:
+            return make_response(jsonify({
+                    "message" : "Cancel failed. no order by that id"
+                }), 400) 


### PR DESCRIPTION
#### What does this PR do?
Configures the PUT cancel order endpoint to the database
### Description of Task to be completed?
- Add view function for a PUT method to the `orders` table
- Add queries for the request in `models.py` located at `app/api/v2/models.py`
#### How should this be manually tested?
visit the link to the API documentation, https://documenter.getpostman.com/view/4014888/RzZDjd3V.
scroll to the PUT method for cancel order. The examples contain the response of both a successful and failed operation