### PR TITLE
[#162119143] Configure GET orders by user endpoint to the database

### DIFF
--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 from flask_restful import Api
-from .views import ParcelList, SingleParcel, ParcelStatus, ParcelLocation, CancelParcel
+from .views import ParcelList, SingleParcel, ParcelStatus, ParcelLocation, CancelParcel, UserOrders
 
 version2 = Blueprint('v2', __name__, url_prefix="/api/v2")
 
@@ -11,3 +11,4 @@ api.add_resource(SingleParcel, '/parcels/<int:id>/destination')
 api.add_resource(ParcelStatus, '/parcels/<int:id>/status')
 api.add_resource(ParcelLocation, '/parcels/<int:id>/presentLocation')
 api.add_resource(CancelParcel, '/parcels/<int:id>/cancel')
+api.add_resource(UserOrders, '/users/<int:id>/parcels')

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -1,14 +1,14 @@
 from flask import Blueprint
 from flask_restful import Api
-from .views import ParcelList, SingleParcel, ParcelStatus, ParcelLocation, CancelParcel, UserOrders
+from .views import ParcelList, ParcelDestination, ParcelStatus, ParcelCurrentLocation, CancelParcel, UserOrders
 
 version2 = Blueprint('v2', __name__, url_prefix="/api/v2")
 
 api = Api(version2)
 
 api.add_resource(ParcelList, '/parcels')
-api.add_resource(SingleParcel, '/parcels/<int:id>/destination')
+api.add_resource(ParcelDestination, '/parcels/<int:id>/destination')
 api.add_resource(ParcelStatus, '/parcels/<int:id>/status')
-api.add_resource(ParcelLocation, '/parcels/<int:id>/presentLocation')
+api.add_resource(ParcelCurrentLocation, '/parcels/<int:id>/presentLocation')
 api.add_resource(CancelParcel, '/parcels/<int:id>/cancel')
 api.add_resource(UserOrders, '/users/<int:id>/parcels')

--- a/app/api/v2/models.py
+++ b/app/api/v2/models.py
@@ -88,4 +88,16 @@ class OrderParcel:
         SenditDb.update_row(status_query)
         return True
 
-        
+    def get_orders_by_user(self, user_id):
+        """
+        retrieves a list of parcels by user id
+        """
+        input_query = """SELECT order_id, item_name, destination, status, \
+         current_location FROM orders WHERE user_id={}""".format(user_id)
+        response = SenditDb.retrieve_all(input_query)
+        if not response:
+            return False
+        payload = {
+            "user orders" : response
+        }
+        return payload

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -159,3 +159,20 @@ class CancelParcel(Resource):
             return make_response(jsonify({
                     "message" : "Cancel failed. no order by that id"
                 }), 400) 
+
+class UserOrders(Resource):
+    """
+    class for endpoint that restrieves all the orders made by a specific user
+    """
+    def get(self, id):
+        user_orders = order.get_orders_by_user(id)
+        if user_orders:
+            return make_response(jsonify({
+                "message" : "Ok",
+                "data" : user_orders
+            }), 200)
+        else:
+            response = {
+                "message" : "Invalid user id"
+            }
+            return make_response(jsonify(response), 400)

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -73,7 +73,7 @@ class ParcelList(Resource):
             }), 400) 
 
 
-class SingleParcel(Resource):
+class ParcelDestination(Resource):
     """
     class for endpoint to allow user to update order destination
     """
@@ -122,7 +122,7 @@ class ParcelStatus(Resource):
                     "message" : "Status entered is invalid"
                 }), 400) 
     
-class ParcelLocation(Resource):
+class ParcelCurrentLocation(Resource):
     """
     class for endpoint to cancel parcel order
     """


### PR DESCRIPTION
#### What does this PR do?
Configures the GET orders by user id endpoint to the database
#### Description of Task to be completed?
- Add GET orders by id endpoint to `views.py` in `app/api/v2/`
- Add queries into the `models.py` to return orders by a particular user from the database
#### How should this be manually tested?
visit the link to the API documentation, https://documenter.getpostman.com/view/4014888/RzZDjd3V.
the GET orders by user id endpoint shows two example responses. one for a successful request and another for a failed one